### PR TITLE
Issue 150 For Windows OS

### DIFF
--- a/icons/CMakeLists.txt
+++ b/icons/CMakeLists.txt
@@ -21,19 +21,23 @@
 set(input_file resources.qrc)
 set(output_file resources.rcc)
 
-# This section checks to see if `rcc` is a recognized command 
-# on the user's Windows OS, and if not, use the `rcc.exe` 
-# file found under the given Maya version.
-find_program(RCC_EXISTS "rcc")
-if(RCC_EXISTS)
-    set(RCC_CMD rcc -binary resources.qrc -o resources.rcc)
-else()
-    set(RCC_CMD "${MAYA_LOCATION}/bin/rcc.exe" -o resources.rcc resources.qrc)
-endif()
+# This section sets a hard location to the rcc  
+# executable file to prevent any errors of 
+# likes of 'rcc command not found'
+find_program(MAYA_RCC_EXECUTABLE
+        rcc
+    HINTS
+        "${MAYA_LOCATION}"
+        "$ENV{MAYA_LOCATION}"
+    PATH_SUFFIXES
+        bin/
+    DOC
+        "Maya's Qt resource compiler rcc executable path"
+)
 
 add_custom_command(
         OUTPUT ${output_file}
-        COMMAND ${RCC_CMD}
+        COMMAND ${MAYA_RCC_EXECUTABLE} -binary resources.qrc -o resources.rcc
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         DEPENDS ${input_file}
 )

--- a/icons/CMakeLists.txt
+++ b/icons/CMakeLists.txt
@@ -20,9 +20,20 @@
 
 set(input_file resources.qrc)
 set(output_file resources.rcc)
+
+# This section checks to see if `rcc` is a recognized command 
+# on the user's Windows OS, and if not, use the `rcc.exe` 
+# file found under the given Maya version.
+find_program(RCC_EXISTS "rcc")
+if(RCC_EXISTS)
+    set(RCC_CMD rcc -binary resources.qrc -o resources.rcc)
+else()
+    set(RCC_CMD "${MAYA_LOCATION}/bin/rcc.exe" -o resources.rcc resources.qrc)
+endif()
+
 add_custom_command(
         OUTPUT ${output_file}
-        COMMAND rcc -binary resources.qrc -o resources.rcc
+        COMMAND ${RCC_CMD}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         DEPENDS ${input_file}
 )

--- a/scripts/build_mmSolver_windows64_maya2016.bat
+++ b/scripts/build_mmSolver_windows64_maya2016.bat
@@ -88,6 +88,12 @@ SET GENERATE_SOLUTION=0
 SET PROJECT_ROOT=%CD%
 ECHO Project Root: %PROJECT_ROOT%
 
+:: Include directories to ignore
+SET IGNORE_INCLUDE_DIRECTORIES=""
+IF EXIST "C:\MinGW" (
+    SET IGNORE_INCLUDE_DIRECTORIES="C:\MinGW\bin;C:\MinGW\include"
+)
+
 :: Build plugin
 MKDIR build_windows64_maya%MAYA_VERSION%_%BUILD_TYPE%
 CHDIR build_windows64_maya%MAYA_VERSION%_%BUILD_TYPE%
@@ -129,6 +135,7 @@ REM To Generate a Visual Studio 'Solution' file
         -DUSE_CMINPACK=%WITH_CMINPACK% ^
         -DCMINPACK_ROOT="%PROJECT_ROOT%\external\install\cminpack" ^
         -DLEVMAR_ROOT="%PROJECT_ROOT%\external\install\levmar" ^
+        -DCMAKE_IGNORE_PATH=%IGNORE_INCLUDE_DIRECTORIES% ^
         -DMAYA_LOCATION=%MAYA_LOCATION% ^
         -DMAYA_VERSION=%MAYA_VERSION% ^
         ..

--- a/scripts/build_mmSolver_windows64_maya2016_extension2.bat
+++ b/scripts/build_mmSolver_windows64_maya2016_extension2.bat
@@ -23,13 +23,13 @@ SETLOCAL
 
 :: Maya directories
 ::
-:: If you're not using Maya 2017 or have a non-standard install location,
+:: If you're not using Maya 2016 or have a non-standard install location,
 :: set these variables here.
 ::
 :: Note: Do not enclose the MAYA_VERSION in quotes, it will
 ::       lead to tears.
-SET MAYA_VERSION=2017
-SET MAYA_LOCATION="C:\Program Files\Autodesk\Maya2017"
+SET MAYA_VERSION=2016.5
+SET MAYA_LOCATION="C:\Program Files\Autodesk\Maya2016.5"
 
 :: Clear all build information before re-compiling.
 :: Turn this off when wanting to make small changes and recompile.
@@ -53,7 +53,7 @@ SET WITH_GPL_CODE=0
 ::       however files copying to "My Documents" automatically go
 ::       to the "Documents" directory.
 ::
-:: The "$HOME/maya/2017/modules" directory is automatically searched
+:: The "$HOME/maya/2016/modules" directory is automatically searched
 :: for Maya module (.mod) files. Therefore we can install directly.
 ::
 :: SET INSTALL_MODULE_DIR="%PROJECT_ROOT%\modules"

--- a/scripts/build_mmSolver_windows64_maya2018.bat
+++ b/scripts/build_mmSolver_windows64_maya2018.bat
@@ -88,6 +88,12 @@ SET GENERATE_SOLUTION=0
 SET PROJECT_ROOT=%CD%
 ECHO Project Root: %PROJECT_ROOT%
 
+:: Include directories to ignore
+SET IGNORE_INCLUDE_DIRECTORIES=""
+IF EXIST "C:\MinGW" (
+    SET IGNORE_INCLUDE_DIRECTORIES="C:\MinGW\bin;C:\MinGW\include"
+)
+
 :: Build plugin
 MKDIR build_windows64_maya%MAYA_VERSION%_%BUILD_TYPE%
 CHDIR build_windows64_maya%MAYA_VERSION%_%BUILD_TYPE%
@@ -129,6 +135,7 @@ REM To Generate a Visual Studio 'Solution' file
         -DUSE_CMINPACK=%WITH_CMINPACK% ^
         -DCMINPACK_ROOT="%PROJECT_ROOT%\external\install\cminpack" ^
         -DLEVMAR_ROOT="%PROJECT_ROOT%\external\install\levmar" ^
+        -DCMAKE_IGNORE_PATH=%IGNORE_INCLUDE_DIRECTORIES% ^
         -DMAYA_LOCATION=%MAYA_LOCATION% ^
         -DMAYA_VERSION=%MAYA_VERSION% ^
         ..

--- a/scripts/build_mmSolver_windows64_maya2019.bat
+++ b/scripts/build_mmSolver_windows64_maya2019.bat
@@ -88,6 +88,12 @@ SET GENERATE_SOLUTION=0
 SET PROJECT_ROOT=%CD%
 ECHO Project Root: %PROJECT_ROOT%
 
+:: Include directories to ignore
+SET IGNORE_INCLUDE_DIRECTORIES=""
+IF EXIST "C:\MinGW" (
+    SET IGNORE_INCLUDE_DIRECTORIES="C:\MinGW\bin;C:\MinGW\include"
+)
+
 :: Build plugin
 MKDIR build_windows64_maya%MAYA_VERSION%_%BUILD_TYPE%
 CHDIR build_windows64_maya%MAYA_VERSION%_%BUILD_TYPE%
@@ -129,6 +135,7 @@ REM To Generate a Visual Studio 'Solution' file
         -DUSE_CMINPACK=%WITH_CMINPACK% ^
         -DCMINPACK_ROOT="%PROJECT_ROOT%\external\install\cminpack" ^
         -DLEVMAR_ROOT="%PROJECT_ROOT%\external\install\levmar" ^
+        -DCMAKE_IGNORE_PATH=%IGNORE_INCLUDE_DIRECTORIES% ^
         -DMAYA_LOCATION=%MAYA_LOCATION% ^
         -DMAYA_VERSION=%MAYA_VERSION% ^
         ..


### PR DESCRIPTION
An attempt to address https://github.com/david-cattermole/mayaMatchMoveSolver/issues/150 on the Windows end.

These changes attempts to address two things:

- The issue of Visual Studio defaulting to source MinGW as its main C++ compiler
- The issue of `rcc` not being found when coming to the part where it builds the UI/Documentation sections (I believe these are the relevant parts)

Initially addressed notes from @david-cattermole from this commit: https://github.com/ktonegawa/mayaMatchMoveSolver/commit/8f14a4241ebcee6478b1df90e9f874db814158b0

I also added a `scripts/build_mmSolver_windows64_maya2016_extension2.bat` so that users who may be using Maya 2016 Extenstion 2 (2016.5) like myself can build this plugin smoothly.