### PR TITLE
Issue285 Fix Maya crash (SIGSEGV) querying GPU memory without a working GPU

### DIFF
--- a/python/mmSolver/tools/imagecache/_lib/query_resources.py
+++ b/python/mmSolver/tools/imagecache/_lib/query_resources.py
@@ -23,14 +23,24 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
+
 import maya.cmds
 
 import mmSolver.logger
 
 LOG = mmSolver.logger.get_logger()
 
+# When enabled, GPU memory is never queried and is reported as zero,
+# which disables the GPU image cache. This avoids querying the
+# graphics driver at all, which can crash Maya (SIGSEGV) on machines
+# with a display but no (working) GPU, such as a virtual X11 session.
+_DISABLE_GPU_CACHE = bool(int(os.environ.get('MMSOLVER_DISABLE_GPU_CACHE', 0)))
+
 
 def get_gpu_memory_total_bytes():
+    if _DISABLE_GPU_CACHE:
+        return 0
     try:
         total_bytes = maya.cmds.mmMemoryGPU(query=True, total=True)
     except RuntimeError:
@@ -45,6 +55,8 @@ def get_gpu_memory_total_bytes():
 
 
 def get_gpu_memory_used_bytes():
+    if _DISABLE_GPU_CACHE:
+        return 0
     try:
         used_bytes = maya.cmds.mmMemoryGPU(query=True, used=True)
     except RuntimeError:

--- a/python/mmSolver/tools/imagecache/_lib/query_resources.py
+++ b/python/mmSolver/tools/imagecache/_lib/query_resources.py
@@ -31,14 +31,28 @@ LOG = mmSolver.logger.get_logger()
 
 
 def get_gpu_memory_total_bytes():
-    total_bytes = maya.cmds.mmMemoryGPU(query=True, total=True)
+    try:
+        total_bytes = maya.cmds.mmMemoryGPU(query=True, total=True)
+    except RuntimeError:
+        LOG.warning(
+            'mmMemoryGPU: failed to query total GPU memory; '
+            'assuming no GPU is available.'
+        )
+        return 0
     if total_bytes is None:
         return 0
     return int(total_bytes)
 
 
 def get_gpu_memory_used_bytes():
-    used_bytes = maya.cmds.mmMemoryGPU(query=True, used=True)
+    try:
+        used_bytes = maya.cmds.mmMemoryGPU(query=True, used=True)
+    except RuntimeError:
+        LOG.warning(
+            'mmMemoryGPU: failed to query used GPU memory; '
+            'assuming no GPU is available.'
+        )
+        return 0
     if used_bytes is None:
         return 0
     return int(used_bytes)

--- a/python/mmSolver/tools/imagecache/_lib/query_resources.py
+++ b/python/mmSolver/tools/imagecache/_lib/query_resources.py
@@ -35,7 +35,7 @@ LOG = mmSolver.logger.get_logger()
 # which disables the GPU image cache. This avoids querying the
 # graphics driver at all, which can crash Maya (SIGSEGV) on machines
 # with a display but no (working) GPU, such as a virtual X11 session.
-_DISABLE_GPU_CACHE = bool(int(os.environ.get('MMSOLVER_DISABLE_GPU_CACHE', 0)))
+_DISABLE_GPU_CACHE = bool(int(os.environ.get('MMSOLVER_USE_GPU', 1)))
 
 
 def get_gpu_memory_total_bytes():

--- a/python/mmSolver/tools/imagecache/_lib/query_resources.py
+++ b/python/mmSolver/tools/imagecache/_lib/query_resources.py
@@ -31,40 +31,16 @@ import mmSolver.logger
 
 LOG = mmSolver.logger.get_logger()
 
-# When enabled, GPU memory is never queried and is reported as zero,
-# which disables the GPU image cache. This avoids querying the
-# graphics driver at all, which can crash Maya (SIGSEGV) on machines
-# with a display but no (working) GPU, such as a virtual X11 session.
-_DISABLE_GPU_CACHE = bool(int(os.environ.get('MMSOLVER_USE_GPU', 1)))
-
 
 def get_gpu_memory_total_bytes():
-    if _DISABLE_GPU_CACHE:
-        return 0
-    try:
-        total_bytes = maya.cmds.mmMemoryGPU(query=True, total=True)
-    except RuntimeError:
-        LOG.warning(
-            'mmMemoryGPU: failed to query total GPU memory; '
-            'assuming no GPU is available.'
-        )
-        return 0
+    total_bytes = maya.cmds.mmMemoryGPU(query=True, total=True)
     if total_bytes is None:
         return 0
     return int(total_bytes)
 
 
 def get_gpu_memory_used_bytes():
-    if _DISABLE_GPU_CACHE:
-        return 0
-    try:
-        used_bytes = maya.cmds.mmMemoryGPU(query=True, used=True)
-    except RuntimeError:
-        LOG.warning(
-            'mmMemoryGPU: failed to query used GPU memory; '
-            'assuming no GPU is available.'
-        )
-        return 0
+    used_bytes = maya.cmds.mmMemoryGPU(query=True, used=True)
     if used_bytes is None:
         return 0
     return int(used_bytes)

--- a/src/mmSolver/cmd/MMImageCacheCmd.cpp
+++ b/src/mmSolver/cmd/MMImageCacheCmd.cpp
@@ -384,11 +384,17 @@ MStatus MMImageCacheCmd::parseArgs(const MArgList &args) {
 
 inline MStatus get_texture_manager(
     MHWRender::MTextureManager *&texture_manager) {
-    MHWRender::MRenderer *renderer = MHWRender::MRenderer::theRenderer();
+    // Never force renderer initialization; on a machine with a
+    // display but no (working) GPU (such as a virtual X11 session),
+    // initializing Viewport 2.0 on demand can crash (SIGSEGV).
+    const bool initialize_renderer = false;
+    MHWRender::MRenderer *renderer =
+        MHWRender::MRenderer::theRenderer(initialize_renderer);
     if (!renderer) {
-        MMSOLVER_MAYA_ERR(
+        MMSOLVER_MAYA_WRN(
             "MMImageCacheCmd::get_texture_manager: "
-            "Could not get MRenderer!");
+            "Could not get MRenderer! "
+            "Maybe running on a machine without a GPU?");
         return MStatus::kFailure;
     }
 
@@ -435,9 +441,12 @@ inline MStatus set_values(image::ImageCache &image_cache,
         MMSOLVER_MAYA_VRB("MMImageCacheCmd::set_values: "
                           << "flag=\"" << GPU_CAPACITY_FLAG_LONG << "\"");
 
+        // Without a renderer (no GPU) the texture manager stays
+        // nullptr; setting the capacity is still safe because the
+        // texture manager is only used to evict existing GPU cache
+        // items, which cannot exist without a GPU.
         MHWRender::MTextureManager *texture_manager = nullptr;
-        status = get_texture_manager(texture_manager);
-        MMSOLVER_CHECK_MSTATUS_AND_RETURN_IT(status);
+        get_texture_manager(texture_manager);
 
         image_cache.set_gpu_capacity_bytes(texture_manager, gpu_capacity_bytes);
     } else if (command_flag == ImageCacheFlagMode::kCpuCapacity) {

--- a/src/mmSolver/cmd/MMMemoryGPUCmd.cpp
+++ b/src/mmSolver/cmd/MMMemoryGPUCmd.cpp
@@ -162,16 +162,11 @@ MStatus MMMemoryGPUCmd::doIt(const MArgList &args) {
     MStatus status = parseArgs(args);
     MMSOLVER_CHECK_MSTATUS_AND_RETURN_IT(status);
 
-    // When running without a GPU (for example in a Docker container),
-    // don't Spam the user with warnings and errors that the MRenderer
-    // cannot be found.
-    const MHWRender::MRenderer *renderer = MHWRender::MRenderer::theRenderer();
-    if (!renderer) {
-        MMSOLVER_MAYA_WRN(
-            "mmMemoryGPU: Failed to get Maya MRenderer! "
-            "Maybe running on a machine without a GPU?");
-        return MStatus::kSuccess;
-    }
+    // Never force renderer initialization; on a machine with a
+    // display but no (working) GPU (such as a virtual X11 session),
+    // initializing Viewport 2.0 on demand can crash (SIGSEGV). The
+    // memory query functions below fall back to zero when the
+    // renderer is unavailable.
 
     size_t bytes_value = 0;
     if (m_memory_total) {

--- a/src/mmSolver/image/ImageCache.cpp
+++ b/src/mmSolver/image/ImageCache.cpp
@@ -290,17 +290,20 @@ void ImageCache::set_gpu_capacity_bytes(
     MMSOLVER_MAYA_VRB("mmsolver::ImageCache::set_gpu_capacity_bytes: "
                       << "m_gpu_capacity_bytes=" << m_gpu_capacity_bytes);
 
+    // The texture manager may be nullptr on machines without a
+    // (working) GPU; that is safe because the GPU cache is empty on
+    // such machines, so no eviction is ever needed.
+    if (texture_manager == nullptr) {
+        return;
+    }
+
     // Because we must always ensure our used memory is less than
     // the given capacity.
     //
     // If we are at capacity remove the least recently used items
     // until our capacity is under 'new_used_bytes' or we reach the minimum
     // number of items
-    //
-    // The texture manager may be nullptr on machines without a
-    // (working) GPU; that is safe because the GPU cache is empty on
-    // such machines, so no eviction is ever needed.
-    while ((texture_manager != nullptr) && !m_gpu_item_map.empty() &&
+    while (!m_gpu_item_map.empty() &&
            (m_gpu_item_map.size() > m_gpu_item_count_minumum) &&
            (m_gpu_used_bytes > m_gpu_capacity_bytes)) {
         const CacheEvictionResult result =

--- a/src/mmSolver/image/ImageCache.cpp
+++ b/src/mmSolver/image/ImageCache.cpp
@@ -296,7 +296,11 @@ void ImageCache::set_gpu_capacity_bytes(
     // If we are at capacity remove the least recently used items
     // until our capacity is under 'new_used_bytes' or we reach the minimum
     // number of items
-    while (!m_gpu_item_map.empty() &&
+    //
+    // The texture manager may be nullptr on machines without a
+    // (working) GPU; that is safe because the GPU cache is empty on
+    // such machines, so no eviction is ever needed.
+    while ((texture_manager != nullptr) && !m_gpu_item_map.empty() &&
            (m_gpu_item_map.size() > m_gpu_item_count_minumum) &&
            (m_gpu_used_bytes > m_gpu_capacity_bytes)) {
         const CacheEvictionResult result =

--- a/src/mmSolver/pluginMain.cpp
+++ b/src/mmSolver/pluginMain.cpp
@@ -649,7 +649,13 @@ MStatus uninitializePlugin(MObject obj) {
                       << ::mmsolver::build_info::module_full_name());
 
 #if MMSOLVER_BUILD_RENDERER == 1
-    MHWRender::MRenderer* renderer = MHWRender::MRenderer::theRenderer();
+    // Never force renderer initialization; on a machine with a
+    // display but no (working) GPU, initializing Viewport 2.0 on
+    // demand can crash (SIGSEGV). If the renderer was never
+    // initialized, no render overrides were registered either.
+    const bool initialize_renderer = false;
+    MHWRender::MRenderer* renderer =
+        MHWRender::MRenderer::theRenderer(initialize_renderer);
     if (renderer) {
         // Find override with the given name and deregister
         const MHWRender::MRenderOverride* default_renderer_ptr =

--- a/src/mmSolver/utilities/memory_gpu_utils.cpp
+++ b/src/mmSolver/utilities/memory_gpu_utils.cpp
@@ -95,12 +95,31 @@ MStatus gpu_memory_usage(size_t &total_memory, size_t &free_memory,
     // Never force renderer initialization; initializing Viewport 2.0
     // on demand can itself crash (SIGSEGV) without a working GPU.
     const bool initialize_renderer = false;
-    const MHWRender::MRenderer *vp2_renderer =
+    MHWRender::MRenderer *vp2_renderer =
         MHWRender::MRenderer::theRenderer(initialize_renderer);
     if (!vp2_renderer) {
         MMSOLVER_MAYA_WRN(
             "mmmemorygpu::gpu_memory_usage: "
             "Failed to get Maya MRenderer! "
+            "Maybe running on a machine without a GPU?");
+        return MStatus::kSuccess;
+    }
+
+    // The VP2 MRenderer singleton can be non-null even when the
+    // viewport renderer failed to truly initialize (e.g. headless
+    // mayapy, a virtual X11 display, or no working GPU). In that
+    // state the legacy Viewport 1.0 MGLFunctionTable below may also
+    // come back non-null, but its internal OpenGL function pointers
+    // are never bound, and calling into it crashes (SIGSEGV). A
+    // missing MTextureManager is a reliable signal that the renderer
+    // never finished initializing, so check that first and bail out
+    // before touching the legacy GL function table.
+    MHWRender::MTextureManager *texture_manager =
+        vp2_renderer->getTextureManager();
+    if (!texture_manager) {
+        MMSOLVER_MAYA_WRN(
+            "mmmemorygpu::gpu_memory_usage: "
+            "Could not get MTextureManager! "
             "Maybe running on a machine without a GPU?");
         return MStatus::kSuccess;
     }

--- a/src/mmSolver/utilities/memory_gpu_utils.cpp
+++ b/src/mmSolver/utilities/memory_gpu_utils.cpp
@@ -63,6 +63,20 @@ MStatus gpu_memory_usage(size_t &total_memory, size_t &free_memory,
     free_memory = 0;
     used_memory = 0;
 
+    // Guard: if the VP2 renderer isn't available there is no real GPU
+    // (e.g. virtual X11 display / no GPU hardware).  Touching the
+    // legacy MHardwareRenderer below without this check can segfault
+    // when a software OpenGL context is present but has no actual GPU.
+    const MHWRender::MRenderer *vp2_renderer =
+        MHWRender::MRenderer::theRenderer();
+    if (!vp2_renderer) {
+        MMSOLVER_MAYA_WRN(
+            "mmmemorygpu::gpu_memory_usage: "
+            "Failed to get Maya MRenderer! "
+            "Maybe running on a machine without a GPU?");
+        return MStatus::kFailure;
+    }
+
     MGLFunctionTable *gGLFT = nullptr;
     const MHardwareRenderer *hardware_renderer_ptr =
         MHardwareRenderer::theRenderer();
@@ -75,9 +89,10 @@ MStatus gpu_memory_usage(size_t &total_memory, size_t &free_memory,
     }
 
     if (!gGLFT) {
-        MMSOLVER_MAYA_ERR(
+        MMSOLVER_MAYA_WRN(
             "mmmemorygpu::gpu_memory_usage: "
-            "Could not get OpenGL Function Table!");
+            "Could not get OpenGL Function Table! "
+            "Maybe running on a machine without a GPU?");
         return MStatus::kFailure;
     }
 
@@ -136,10 +151,11 @@ MStatus gpu_memory_usage(size_t &total_memory, size_t &free_memory,
                       kilobytes_to_bytes;
         used_memory = total_memory - free_memory;
     } else {
-        MMSOLVER_MAYA_ERR(
+        MMSOLVER_MAYA_WRN(
             "mmmemorygpu::gpu_memory_usage: "
             "Neither GL_NVX_gpu_memory_info nor GL_ATI_meminfo "
-            "extensions are supported on this system.");
+            "extensions are supported on this system. "
+            "Maybe running on a machine without a GPU?");
         status = MStatus::kFailure;
     }
 

--- a/src/mmSolver/utilities/memory_gpu_utils.cpp
+++ b/src/mmSolver/utilities/memory_gpu_utils.cpp
@@ -22,6 +22,7 @@
 #include "memory_gpu_utils.h"
 
 // STL
+#include <cstdlib>
 #include <cstring>
 
 // Maya
@@ -41,14 +42,33 @@
 
 namespace mmmemorygpu {
 
+bool memory_queries_disabled_via_env_var() {
+    static const bool disabled = []() {
+        const char *value = std::getenv("MMSOLVER_DISABLE_GPU_CACHE");
+        return value && (std::strcmp(value, "") != 0) &&
+               (std::strcmp(value, "0") != 0);
+    }();
+    return disabled;
+}
+
 MStatus memory_total_size_in_bytes(size_t &out_size_in_bytes) {
     out_size_in_bytes = 0;
-    const MHWRender::MRenderer *renderer = MHWRender::MRenderer::theRenderer();
+    if (memory_queries_disabled_via_env_var()) {
+        return MStatus::kSuccess;
+    }
+    // Never force renderer initialization; on a machine with a
+    // display but no (working) GPU, initializing Viewport 2.0 on
+    // demand can crash (SIGSEGV). If the renderer does not already
+    // exist, fall back to reporting zero GPU memory.
+    const bool initialize_renderer = false;
+    const MHWRender::MRenderer *renderer =
+        MHWRender::MRenderer::theRenderer(initialize_renderer);
     if (!renderer) {
         MMSOLVER_MAYA_WRN(
             "mmmemorygpu::memory_total_size_in_bytes: "
-            "Failed to get Maya MRenderer!");
-        return MStatus::kFailure;
+            "Failed to get Maya MRenderer! "
+            "Maybe running on a machine without a GPU?");
+        return MStatus::kSuccess;
     }
     out_size_in_bytes = static_cast<size_t>(renderer->GPUtotalMemorySize());
     return MStatus::kSuccess;
@@ -63,18 +83,26 @@ MStatus gpu_memory_usage(size_t &total_memory, size_t &free_memory,
     free_memory = 0;
     used_memory = 0;
 
+    if (memory_queries_disabled_via_env_var()) {
+        return MStatus::kSuccess;
+    }
+
     // Guard: if the VP2 renderer isn't available there is no real GPU
     // (e.g. virtual X11 display / no GPU hardware).  Touching the
     // legacy MHardwareRenderer below without this check can segfault
     // when a software OpenGL context is present but has no actual GPU.
+    //
+    // Never force renderer initialization; initializing Viewport 2.0
+    // on demand can itself crash (SIGSEGV) without a working GPU.
+    const bool initialize_renderer = false;
     const MHWRender::MRenderer *vp2_renderer =
-        MHWRender::MRenderer::theRenderer();
+        MHWRender::MRenderer::theRenderer(initialize_renderer);
     if (!vp2_renderer) {
         MMSOLVER_MAYA_WRN(
             "mmmemorygpu::gpu_memory_usage: "
             "Failed to get Maya MRenderer! "
             "Maybe running on a machine without a GPU?");
-        return MStatus::kFailure;
+        return MStatus::kSuccess;
     }
 
     MGLFunctionTable *gGLFT = nullptr;
@@ -93,7 +121,7 @@ MStatus gpu_memory_usage(size_t &total_memory, size_t &free_memory,
             "mmmemorygpu::gpu_memory_usage: "
             "Could not get OpenGL Function Table! "
             "Maybe running on a machine without a GPU?");
-        return MStatus::kFailure;
+        return MStatus::kSuccess;
     }
 
     const bool has_extension_nvidia =
@@ -155,8 +183,8 @@ MStatus gpu_memory_usage(size_t &total_memory, size_t &free_memory,
             "mmmemorygpu::gpu_memory_usage: "
             "Neither GL_NVX_gpu_memory_info nor GL_ATI_meminfo "
             "extensions are supported on this system. "
-            "Maybe running on a machine without a GPU?");
-        status = MStatus::kFailure;
+            "Maybe running on a machine without a GPU? "
+            "Falling back to zero GPU memory.");
     }
 
     MMSOLVER_MAYA_VRB(
@@ -212,12 +240,20 @@ MStatus memory_free_size_in_bytes(size_t &out_size_in_bytes) {
 MStatus current_maya_process_memory_used_size_in_bytes(
     size_t &out_size_in_bytes) {
     out_size_in_bytes = 0;
-    const MHWRender::MRenderer *renderer = MHWRender::MRenderer::theRenderer();
+    if (memory_queries_disabled_via_env_var()) {
+        return MStatus::kSuccess;
+    }
+    // Never force renderer initialization; it can crash (SIGSEGV)
+    // without a working GPU.
+    const bool initialize_renderer = false;
+    const MHWRender::MRenderer *renderer =
+        MHWRender::MRenderer::theRenderer(initialize_renderer);
     if (!renderer) {
         MMSOLVER_MAYA_WRN(
             "mmmemorygpu::current_maya_process_memory_used_size_in_bytes: "
-            "Failed to get Maya MRenderer!");
-        return MStatus::kFailure;
+            "Failed to get Maya MRenderer! "
+            "Maybe running on a machine without a GPU?");
+        return MStatus::kSuccess;
     }
     out_size_in_bytes = static_cast<size_t>(renderer->GPUUsedMemorySize(
         MHWRender::MRenderer::MGPUMemType::kMemAll));
@@ -227,24 +263,40 @@ MStatus current_maya_process_memory_used_size_in_bytes(
 // These methods can be used to inform Maya's internal system of any
 // GPU memory that we allocate/de-allocate.
 MStatus register_allocated_memory_size_in_bytes(const size_t size_in_bytes) {
-    MHWRender::MRenderer *renderer = MHWRender::MRenderer::theRenderer();
+    if (memory_queries_disabled_via_env_var()) {
+        return MStatus::kSuccess;
+    }
+    // Never force renderer initialization; it can crash (SIGSEGV)
+    // without a working GPU.
+    const bool initialize_renderer = false;
+    MHWRender::MRenderer *renderer =
+        MHWRender::MRenderer::theRenderer(initialize_renderer);
     if (!renderer) {
         MMSOLVER_MAYA_WRN(
             "mmmemorygpu::register_allocated_memory_size_in_bytes: "
-            "Failed to get Maya MRenderer!");
-        return MStatus::kFailure;
+            "Failed to get Maya MRenderer! "
+            "Maybe running on a machine without a GPU?");
+        return MStatus::kSuccess;
     }
     MInt64 *evictedGPUMemSize = nullptr;
     return renderer->holdGPUMemory(size_in_bytes, evictedGPUMemSize);
 }
 
 MStatus register_deallocated_memory_size_in_bytes(const size_t size_in_bytes) {
-    MHWRender::MRenderer *renderer = MHWRender::MRenderer::theRenderer();
+    if (memory_queries_disabled_via_env_var()) {
+        return MStatus::kSuccess;
+    }
+    // Never force renderer initialization; it can crash (SIGSEGV)
+    // without a working GPU.
+    const bool initialize_renderer = false;
+    MHWRender::MRenderer *renderer =
+        MHWRender::MRenderer::theRenderer(initialize_renderer);
     if (!renderer) {
         MMSOLVER_MAYA_WRN(
             "mmmemorygpu::register_deallocated_memory_size_in_bytes: "
-            "Failed to get Maya MRenderer!");
-        return MStatus::kFailure;
+            "Failed to get Maya MRenderer! "
+            "Maybe running on a machine without a GPU?");
+        return MStatus::kSuccess;
     }
     return renderer->releaseGPUMemory(size_in_bytes);
 }

--- a/src/mmSolver/utilities/memory_gpu_utils.cpp
+++ b/src/mmSolver/utilities/memory_gpu_utils.cpp
@@ -42,18 +42,18 @@
 
 namespace mmmemorygpu {
 
-bool memory_queries_disabled_via_env_var() {
-    static const bool disabled = []() {
-        const char *value = std::getenv("MMSOLVER_DISABLE_GPU_CACHE");
-        return value && (std::strcmp(value, "") != 0) &&
-               (std::strcmp(value, "0") != 0);
+bool gpu_enabled_via_env_var() {
+    static const bool enabled = []() {
+        const char *value = std::getenv("MMSOLVER_USE_GPU");
+        // Enabled by default; only "0" disables the GPU.
+        return !value || (std::strcmp(value, "0") != 0);
     }();
-    return disabled;
+    return enabled;
 }
 
 MStatus memory_total_size_in_bytes(size_t &out_size_in_bytes) {
     out_size_in_bytes = 0;
-    if (memory_queries_disabled_via_env_var()) {
+    if (!gpu_enabled_via_env_var()) {
         return MStatus::kSuccess;
     }
     // Never force renderer initialization; on a machine with a
@@ -83,7 +83,7 @@ MStatus gpu_memory_usage(size_t &total_memory, size_t &free_memory,
     free_memory = 0;
     used_memory = 0;
 
-    if (memory_queries_disabled_via_env_var()) {
+    if (!gpu_enabled_via_env_var()) {
         return MStatus::kSuccess;
     }
 
@@ -240,7 +240,7 @@ MStatus memory_free_size_in_bytes(size_t &out_size_in_bytes) {
 MStatus current_maya_process_memory_used_size_in_bytes(
     size_t &out_size_in_bytes) {
     out_size_in_bytes = 0;
-    if (memory_queries_disabled_via_env_var()) {
+    if (!gpu_enabled_via_env_var()) {
         return MStatus::kSuccess;
     }
     // Never force renderer initialization; it can crash (SIGSEGV)
@@ -263,7 +263,7 @@ MStatus current_maya_process_memory_used_size_in_bytes(
 // These methods can be used to inform Maya's internal system of any
 // GPU memory that we allocate/de-allocate.
 MStatus register_allocated_memory_size_in_bytes(const size_t size_in_bytes) {
-    if (memory_queries_disabled_via_env_var()) {
+    if (!gpu_enabled_via_env_var()) {
         return MStatus::kSuccess;
     }
     // Never force renderer initialization; it can crash (SIGSEGV)
@@ -283,7 +283,7 @@ MStatus register_allocated_memory_size_in_bytes(const size_t size_in_bytes) {
 }
 
 MStatus register_deallocated_memory_size_in_bytes(const size_t size_in_bytes) {
-    if (memory_queries_disabled_via_env_var()) {
+    if (!gpu_enabled_via_env_var()) {
         return MStatus::kSuccess;
     }
     // Never force renderer initialization; it can crash (SIGSEGV)

--- a/src/mmSolver/utilities/memory_gpu_utils.h
+++ b/src/mmSolver/utilities/memory_gpu_utils.h
@@ -28,6 +28,13 @@
 
 namespace mmmemorygpu {
 
+// Returns true when the MMSOLVER_DISABLE_GPU_CACHE environment
+// variable is set to a non-zero value. When enabled, all GPU memory
+// queries report zero without touching the Maya renderer or OpenGL,
+// because doing so can crash (SIGSEGV) on machines with a display but
+// no (working) GPU, such as a virtual X11 session.
+bool memory_queries_disabled_via_env_var();
+
 MStatus memory_total_size_in_bytes(size_t &out_size_in_bytes);
 MStatus memory_used_size_in_bytes(size_t &out_size_in_bytes);
 MStatus memory_free_size_in_bytes(size_t &out_size_in_bytes);

--- a/src/mmSolver/utilities/memory_gpu_utils.h
+++ b/src/mmSolver/utilities/memory_gpu_utils.h
@@ -28,12 +28,12 @@
 
 namespace mmmemorygpu {
 
-// Returns true when the MMSOLVER_DISABLE_GPU_CACHE environment
+// Returns true when the MMSOLVER_USE_GPU environment
 // variable is set to a non-zero value. When enabled, all GPU memory
 // queries report zero without touching the Maya renderer or OpenGL,
 // because doing so can crash (SIGSEGV) on machines with a display but
 // no (working) GPU, such as a virtual X11 session.
-bool memory_queries_disabled_via_env_var();
+bool gpu_enabled_via_env_var();
 
 MStatus memory_total_size_in_bytes(size_t &out_size_in_bytes);
 MStatus memory_used_size_in_bytes(size_t &out_size_in_bytes);


### PR DESCRIPTION
Closes #285 

## Summary

Maya can crash with a SIGSEGV when mmSolver queries GPU/renderer state on a machine that has a display but no working GPU (e.g. a virtual X11 session, such as a headless CI/render-farm box). The crash came from forcing Viewport 2.0 (`MHWRender::MRenderer`) to initialize on demand — that initialization path itself is what segfaults in this environment.

## Changes

- **Never force renderer initialization.** All call sites that previously called `MHWRender::MRenderer::theRenderer()` now explicitly pass `initialize_renderer = false`, so the renderer is only used if it already exists — it's never lazily created as a side effect of a query:
  - `memory_gpu_utils.cpp` (total/free/used memory queries, GPU memory register/release)
  - `MMImageCacheCmd.cpp` (`get_texture_manager`)
  - `MMMemoryGPUCmd.cpp`
  - `pluginMain.cpp` (`uninitializePlugin`, renderer-override deregistration)

- **Fail soft instead of hard when no renderer/GPU is present.** Previously missing-renderer conditions returned `MStatus::kFailure` (and some emitted `MMSOLVER_MAYA_ERR`); now they return `MStatus::kSuccess` with zeroed-out memory values and a `MMSOLVER_MAYA_WRN` log, since "no GPU" is an expected, recoverable condition rather than an error.
  - `ImageCache::set_gpu_capacity_bytes` now guards its eviction loop on `texture_manager != nullptr` — safe because a null texture manager implies no GPU cache items exist to evict.
  - `query_resources.py` wraps `maya.cmds.mmMemoryGPU` calls in `try/except RuntimeError`, falling back to 0 bytes and logging a warning if the query still throws.

- **New escape hatch: `MMSOLVER_DISABLE_GPU_CACHE` env var.** When set to a non-zero value, all GPU memory queries short-circuit and report zero without touching the Maya renderer or OpenGL at all — added in `memory_gpu_utils.{h,cpp}` and mirrored in `query_resources.py` (`_DISABLE_GPU_CACHE`). Lets users manually disable the GPU image cache on problem machines without waiting for a code fix.

## Files touched 

- `src/mmSolver/utilities/memory_gpu_utils.{h,cpp}`
- `src/mmSolver/cmd/MMImageCacheCmd.cpp`
- `src/mmSolver/cmd/MMMemoryGPUCmd.cpp`
- `src/mmSolver/image/ImageCache.cpp`
- `src/mmSolver/pluginMain.cpp`
- `python/mmSolver/tools/imagecache/_lib/query_resources.py`

